### PR TITLE
Add alternate poltergeist_debug driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ page.find(book_2).drag_to(page.find(book_1))
 
 Switches javascript driver to poltergeist
 
+To use Poltegeist with [remote debugging](https://github.com/teampoltergeist/poltergeist/blob/master/README.md#remote-debugging-experimental), run test with `POLTERGEIST_DEBUG` set.
+
+```sh
+POLTERGEIST_DEBUG=1 rspec spec/features/broken_feature_spec.rb
+```
+
 ### capybara_screenshot
 
 Automatically saves an html file viewable at

--- a/lib/utensils/capybara_javascript.rb
+++ b/lib/utensils/capybara_javascript.rb
@@ -1,2 +1,10 @@
 require 'capybara/poltergeist'
-Capybara.javascript_driver = :poltergeist
+Capybara.register_driver :poltergeist_debug do |app|
+  Capybara::Poltergeist::Driver.new(app, inspector: true)
+end
+
+Capybara.javascript_driver = if ENV["POLTERGEIST_DEBUG"]
+                               :poltergeist_debug
+                             else
+                               :poltergeist
+                             end


### PR DESCRIPTION
To aid in debugging feature specs using Poltergeist, I want to be able 
to use remote debugging to use the Webkit inspector while the test is running.

After this change, running rspec with the `POLTERGEIST_DEBUG` envvar set will enable
Poltergeist's `inspector` option for remote debugging.

e.g.
`POLTERGEIST_DEBUG=1 rspec spec/features/my_broken_feature.rb:100`

Inserting `page.driver.debug` in examples will launch a browser to allow
debugging with the Webkit Inspector

Reference: http://jonathanleighton.com/articles/2012/poltergeist-0-6-0/

WDYT @balvig ?

I'll also update the README if this proposal is acceptable.