### PR TITLE
Add a :role selector to Capybara, based on data-role attribute

### DIFF
--- a/lib/utensils/capybara_extensions.rb
+++ b/lib/utensils/capybara_extensions.rb
@@ -3,3 +3,7 @@ Capybara.add_selector :record do
   xpath { |record| XPath.css("#" + identifier.dom_id(record)) }
   match { |record| record.is_a?(ActiveRecord::Base) }
 end
+
+Capybara.add_selector(:role) do
+  css { |role| %([data-role="#{role}"]) }
+end

--- a/lib/utensils/custom_matchers.rb
+++ b/lib/utensils/custom_matchers.rb
@@ -146,6 +146,16 @@ module Utensils
     def have_order(*args)
       Ordered.new(args)
     end
+
+    class HaveRole < Capybara::RSpecMatchers::HaveSelector
+      def initialize(role, *args, &filter_block)
+        super(:role, role, *args, &filter_block)
+      end
+    end
+
+    def have_role(*args)
+      HaveRole.new(*args)
+    end
   end
 end
 


### PR DESCRIPTION
Alllows:

```html
<li data-role="recipe">
```

```rb

within(:role, "recipe") do
  # ...
end

expect(page).to have_role?("recipe")

expect(page).to have_role?("recipe", count: 20)

page.find_all(:role, "recipe")
```