### PR TITLE
Remove capybara-screenshot utensils

### DIFF
--- a/lib/utensils/capybara_screenshot.rb
+++ b/lib/utensils/capybara_screenshot.rb
@@ -1,4 +1,0 @@
-require 'capybara-screenshot/rspec'
-Capybara.save_path = 'public/tmp'
-Capybara::Screenshot::RSpec.add_link_to_screenshot_for_failed_examples = false
-Capybara::Screenshot.append_timestamp = false


### PR DESCRIPTION
This should allow developers to view all of the test failures screenshots if they save them as an artifact on the CI server, instead of having the file get overridden because it has the same filename.

Also, this will restore the path where the screenshot will be save, so it can be overridden by the underlying apps if needed.

---

**Update:** After some further internal discussion, we decided to remove this utensils altogether. I've updated the PR to reflect this.