### PR TITLE
Update lazy loaded image matcher to match data-src

### DIFF
--- a/lib/utensils/custom_matchers.rb
+++ b/lib/utensils/custom_matchers.rb
@@ -94,8 +94,7 @@ module Utensils
         end
 
         def find_lazy_loaded_image
-          @page.has_css?("img[data-original$='#{@image}']") || 
-            @page.has_css?("img[data-src$='#{@image}']")
+          @page.has_css?("img[data-src$='#{@image}']")
         end
 
         def find_dragonfly_image

--- a/lib/utensils/custom_matchers.rb
+++ b/lib/utensils/custom_matchers.rb
@@ -94,7 +94,8 @@ module Utensils
         end
 
         def find_lazy_loaded_image
-          @page.has_css?("img[data-original$='#{@image}']")
+          @page.has_css?("img[data-original$='#{@image}']") || 
+            @page.has_css?("img[data-src$='#{@image}']")
         end
 
         def find_dragonfly_image


### PR DESCRIPTION
It seems using the data-src attribute is a convention now but I will keep the data-original for backward compatibility.

See https://github.com/verlok/lazyload