### PR TITLE
Add `visible: false` option to lazy loaded image matcher

### DIFF
--- a/lib/utensils/custom_matchers.rb
+++ b/lib/utensils/custom_matchers.rb
@@ -94,7 +94,7 @@ module Utensils
         end
 
         def find_lazy_loaded_image
-          @page.has_css?("img[data-src$='#{@image}']")
+          @page.has_css?("img[data-src$='#{@image}']", visible: false)
         end
 
         def find_dragonfly_image


### PR DESCRIPTION
https://github.com/balvig/utensils/pull/15 amended the lazy loaded image matcher.
It looks as if, in order for the matcher to correctly match lazy loads, it requires `visible: false` as in:
https://github.com/cookpad/global-web/blob/21da0db41f57cabb448ad2c13a4cb73604ae8dee/spec/support/matchers/have_lazy_loaded_image.rb#L3