### PR TITLE
Fix JSON helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ require 'utensils/email'
 require 'utensils/factory_bot'
 require 'utensils/omniauth'
 require 'utensils/upload_macros'
+require 'utensils/json'
 ```
 
 ### capybara_extensions

--- a/lib/utensils/json.rb
+++ b/lib/utensils/json.rb
@@ -1,3 +1,6 @@
+require "launchy"
+require "multi_json"
+
 module JsonHelpers
   def expect_json_response(path = nil)
     expect(json_response(path))

--- a/utensils.gemspec
+++ b/utensils.gemspec
@@ -14,4 +14,7 @@ Gem::Specification.new do |gem|
   gem.name          = "utensils"
   gem.require_paths = ["lib"]
   gem.version       = Utensils::VERSION
+
+  gem.add_dependency "launchy"
+  gem.add_dependency "multi_json"
 end


### PR DESCRIPTION
Dropping `utensils` into a vanilla project, then calling `save_and_open_json` results in a couple of exceptions:

```
     NameError:
       uninitialized constant JsonHelpers::Launchy
     # /Users/lewis/projects/utensils/lib/utensils/json.rb:22:in `save_and_open_json'
```

and

```
     NameError:
       uninitialized constant JsonHelpers::MultiJson
       Did you mean?  MultiXml
     # /Users/lewis/projects/utensils/lib/utensils/json.rb:35:in `parse_json'
```

This PR fixes these errors and closes https://github.com/balvig/utensils/issues/11

I also took the opportunity to advertise the JSON helpers in the readme!

PS. I hope you're keeping well @balvig ! 😄 